### PR TITLE
Expose Base64 constructor

### DIFF
--- a/core/src/Network/AWS/Data/Internal/Base64.hs
+++ b/core/src/Network/AWS/Data/Internal/Base64.hs
@@ -12,7 +12,7 @@
 -- Portability : non-portable (GHC extensions)
 
 module Network.AWS.Data.Internal.Base64
-    ( Base64
+    ( Base64 (..)
     ) where
 
 import           Data.Aeson.Types

--- a/core/src/Network/AWS/Data/Internal/Base64.hs
+++ b/core/src/Network/AWS/Data/Internal/Base64.hs
@@ -28,6 +28,8 @@ import           Network.AWS.Data.Internal.Text
 import           Network.AWS.Data.Internal.XML
 
 -- | Base64 encoded binary data.
+--
+-- Encoding/decoding is deferred to serialisation/deserialisation respectively.
 newtype Base64 = Base64 { unBase64 :: ByteString }
     deriving (Eq, Read, Ord, Generic)
 


### PR DESCRIPTION
Some endpoints require the user to create values of type `Base64` (one example is kinesis' [PutRecords](http://hackage.haskell.org/package/amazonka-kinesis-0.3.4/docs/Network-AWS-Kinesis-PutRecords.html)). However, it appears to be impossible to create one from raw bytes.
